### PR TITLE
Fetch lesson's content from Moodle to Versapath

### DIFF
--- a/src/main/java/com/capstone/lms_service/controller/MoodleController.java
+++ b/src/main/java/com/capstone/lms_service/controller/MoodleController.java
@@ -75,4 +75,17 @@ public class MoodleController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @GetMapping("/fetch-single-content")
+    @Operation(summary = "Fetch single content from Moodle", description = "This is a direct endpoint to fetch lesson content")
+    public ResponseEntity<?> fetchSingleContent(@RequestParam int pageId) throws JsonProcessingException {
+        MoodlePageContentResponse responseCourse = courseService.fetchSingleContent(pageId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Fetch contents successfully!")
+                .errors(null)
+                .data(Map.of("item", responseCourse))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
 }

--- a/src/main/java/com/capstone/lms_service/controller/MoodleController.java
+++ b/src/main/java/com/capstone/lms_service/controller/MoodleController.java
@@ -13,12 +13,10 @@ import org.common.event.CreateSkillEvent;
 import org.common.event.ProduceUserEvent;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,6 +45,19 @@ public class MoodleController {
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Course inserted successfully!")
+                .errors(null)
+                .data(Map.of("item", responseCourse))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping("/enrol-learner")
+    @Operation(summary = "Insert learner on moodle", description = "This is a direct endpoint to insert leaner from Versapath to moodle ")
+    public ResponseEntity<?> createCourse(@RequestParam int moodleLearnerId, @RequestParam int moodleCourseId) throws JsonProcessingException {
+        String responseCourse = courseService.enrolLearnerInCourse(moodleLearnerId, moodleCourseId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Learner enrolled successfully!")
                 .errors(null)
                 .data(Map.of("item", responseCourse))
                 .build();

--- a/src/main/java/com/capstone/lms_service/controller/MoodleController.java
+++ b/src/main/java/com/capstone/lms_service/controller/MoodleController.java
@@ -1,9 +1,6 @@
 package com.capstone.lms_service.controller;
 
-import com.capstone.lms_service.dto.ClientResponseFormatDto;
-import com.capstone.lms_service.dto.MoodleCourseResponse;
-import com.capstone.lms_service.dto.MoodleUserResponse;
-import com.capstone.lms_service.dto.UserRequestDto;
+import com.capstone.lms_service.dto.*;
 import com.capstone.lms_service.service.CourseService;
 import com.capstone.lms_service.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -39,7 +37,7 @@ public class MoodleController {
     }
 
     @PostMapping("/create-course")
-    @Operation(summary = "Insert learner on moodle", description = "This is a direct endpoint to insert leaner from Versapath to moodle ")
+    @Operation(summary = "Create course on moodle", description = "This is a direct endpoint to create skill structure on Moodle ")
     public ResponseEntity<?> createCourse(@RequestBody CreateSkillEvent skillEvent) throws JsonProcessingException {
         MoodleCourseResponse responseCourse = courseService.createMoodleCourseStructure(skillEvent);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
@@ -52,12 +50,25 @@ public class MoodleController {
     }
 
     @PostMapping("/enrol-learner")
-    @Operation(summary = "Insert learner on moodle", description = "This is a direct endpoint to insert leaner from Versapath to moodle ")
-    public ResponseEntity<?> createCourse(@RequestParam int moodleLearnerId, @RequestParam int moodleCourseId) throws JsonProcessingException {
+    @Operation(summary = "Enrol learner in a course", description = "This is a direct endpoint to enrol a learner in course")
+    public ResponseEntity<?> enrolLearnerInCourse(@RequestParam int moodleLearnerId, @RequestParam int moodleCourseId) throws JsonProcessingException {
         String responseCourse = courseService.enrolLearnerInCourse(moodleLearnerId, moodleCourseId);
         ClientResponseFormatDto response = ClientResponseFormatDto.builder()
                 .success(true)
                 .message("Learner enrolled successfully!")
+                .errors(null)
+                .data(Map.of("item", responseCourse))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/fetch-content")
+    @Operation(summary = "Fetch content from Moodle", description = "This is a direct endpoint to fetch lesson content")
+    public ResponseEntity<?> fetchContent(@RequestParam int moodleCourseId) throws JsonProcessingException {
+        List<MoodlePageContentResponse> responseCourse = courseService.fetchContent(moodleCourseId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Fetch contents successfully!")
                 .errors(null)
                 .data(Map.of("item", responseCourse))
                 .build();

--- a/src/main/java/com/capstone/lms_service/dto/MoodleEnroleResponse.java
+++ b/src/main/java/com/capstone/lms_service/dto/MoodleEnroleResponse.java
@@ -1,0 +1,17 @@
+package com.capstone.lms_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MoodleEnroleResponse {
+    private int cmid; // id for tracking progress
+    private int instance; // id for fetching content
+    private String name; // atom name
+    private int courseid; // course/capsule id
+}

--- a/src/main/java/com/capstone/lms_service/dto/MoodlePageContentResponse.java
+++ b/src/main/java/com/capstone/lms_service/dto/MoodlePageContentResponse.java
@@ -1,0 +1,21 @@
+package com.capstone.lms_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MoodlePageContentResponse {
+    private int id; // instance id of page
+    private int course; // course id
+    private String name; // atom/lesson name
+    private String intro;
+    private int coursemodule;
+    private String content;
+}

--- a/src/main/java/com/capstone/lms_service/dto/PageContentResponse.java
+++ b/src/main/java/com/capstone/lms_service/dto/PageContentResponse.java
@@ -1,0 +1,18 @@
+package com.capstone.lms_service.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PageContentResponse {
+    List<MoodlePageContentResponse> pages;
+}

--- a/src/main/java/com/capstone/lms_service/service/CourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/CourseService.java
@@ -6,4 +6,5 @@ import org.common.event.CreateSkillEvent;
 
 public interface CourseService {
     MoodleCourseResponse createMoodleCourseStructure(CreateSkillEvent skillEvent) throws JsonProcessingException;
+    String enrolLearnerInCourse(int moodleLeanerId, int moodleCourseId) throws JsonProcessingException;
 }

--- a/src/main/java/com/capstone/lms_service/service/CourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/CourseService.java
@@ -1,10 +1,14 @@
 package com.capstone.lms_service.service;
 
 import com.capstone.lms_service.dto.MoodleCourseResponse;
+import com.capstone.lms_service.dto.MoodlePageContentResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.common.event.CreateSkillEvent;
+
+import java.util.List;
 
 public interface CourseService {
     MoodleCourseResponse createMoodleCourseStructure(CreateSkillEvent skillEvent) throws JsonProcessingException;
     String enrolLearnerInCourse(int moodleLeanerId, int moodleCourseId) throws JsonProcessingException;
+    List<MoodlePageContentResponse> fetchContent(int moodleCourseId) throws JsonProcessingException;
 }

--- a/src/main/java/com/capstone/lms_service/service/CourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/CourseService.java
@@ -11,4 +11,5 @@ public interface CourseService {
     MoodleCourseResponse createMoodleCourseStructure(CreateSkillEvent skillEvent) throws JsonProcessingException;
     String enrolLearnerInCourse(int moodleLeanerId, int moodleCourseId) throws JsonProcessingException;
     List<MoodlePageContentResponse> fetchContent(int moodleCourseId) throws JsonProcessingException;
+    MoodlePageContentResponse fetchSingleContent(int moodleCourseId) throws JsonProcessingException;
 }

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
@@ -52,6 +52,26 @@ public class MoodleCourseService implements CourseService {
         return insertedCourse;
     }
 
+    @Override
+    public String enrolLearnerInCourse(int moodleLeanerId, int moodleCourseId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + token + "&wsfunction=enrol_manual_enrol_users&moodlewsrestformat=json";
+
+        //moodle expects parameters as below
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("enrolments[0][roleid]","5"); // this is for learner
+        params.add("enrolments[0][userid]",""+moodleLeanerId+"");
+        params.add("enrolments[0][courseid]",""+moodleCourseId+"");
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url); // send request
+        String response = objectMapper.readValue(
+                root.toString(),
+                new TypeReference<>() {}); // the success response is an empty array
+
+        logger.info("Learner enrolled successfully: {}", moodleLeanerId);
+
+        return "Enrolled learner id "+moodleCourseId;
+    }
+
     public MoodleCourseResponse createCourse(String capsuleName) throws JsonProcessingException {
         String url = moodleUrl + "?wstoken=" + token + "&wsfunction=core_course_create_courses&moodlewsrestformat=json";
 
@@ -74,7 +94,7 @@ public class MoodleCourseService implements CourseService {
                 new TypeReference<>() {}
         );
 
-        logger.info("Course created successfule: {}", courses.get(0).getShortname());
+        logger.info("Course created successful: {}", courses.get(0).getShortname());
 
         return courses.get(0);
     }
@@ -99,7 +119,7 @@ public class MoodleCourseService implements CourseService {
             MoodlePageResponse response = objectMapper.treeToValue(root, MoodlePageResponse.class);
 
             pageResponseList.add(response);
-            logger.info("Page created successfule: {}", response.getName());
+            logger.info("Page created successful: {}", response.getName());
 
         }
 

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
@@ -42,6 +42,9 @@ public class MoodleCourseService implements CourseService {
     @Value("${LOCAL_WEBSERVICE_TOKEN}")
     private String localToken;
 
+    @Value("${LOCAL_SINGLE_PAGE_TOKEN}")
+    private String singlePageToken; // custom php function
+
     @Override
     public MoodleCourseResponse createMoodleCourseStructure(CreateSkillEvent skillEvent) throws JsonProcessingException {
         logger.info("inside the course {}", skillEvent);
@@ -90,6 +93,24 @@ public class MoodleCourseService implements CourseService {
 
         logger.info("Fetched page content successfully for courseId={}", moodleCourseId);
         return response.getPages();
+    }
+
+    @Override
+    public MoodlePageContentResponse fetchSingleContent(int pageId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + singlePageToken + "&wsfunction=local_singlepage_get_page&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("pageid", String.valueOf(pageId));
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+
+        MoodlePageContentResponse response = objectMapper.readValue(
+                root.toString(),
+                MoodlePageContentResponse.class
+        );
+
+        logger.info("Fetched single page content successfully for courseId={}", pageId);
+        return response;
     }
 
     public MoodleCourseResponse createCourse(String capsuleName) throws JsonProcessingException {

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
@@ -1,7 +1,9 @@
 package com.capstone.lms_service.service.impl;
 
 import com.capstone.lms_service.dto.MoodleCourseResponse;
+import com.capstone.lms_service.dto.MoodlePageContentResponse;
 import com.capstone.lms_service.dto.MoodlePageResponse;
+import com.capstone.lms_service.dto.PageContentResponse;
 import com.capstone.lms_service.messaging.UpdateSkillProducer;
 import com.capstone.lms_service.service.CourseService;
 import com.capstone.lms_service.util.MoodleHttpRequest;
@@ -59,8 +61,8 @@ public class MoodleCourseService implements CourseService {
         //moodle expects parameters as below
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("enrolments[0][roleid]","5"); // this is for learner
-        params.add("enrolments[0][userid]",""+moodleLeanerId+"");
-        params.add("enrolments[0][courseid]",""+moodleCourseId+"");
+        params.add("enrolments[0][userid]",String.valueOf(moodleLeanerId));
+        params.add("enrolments[0][courseid]",String.valueOf(moodleCourseId));
 
         JsonNode root = moodleHttpRequest.sendRequest(params, url); // send request
         String response = objectMapper.readValue(
@@ -70,6 +72,24 @@ public class MoodleCourseService implements CourseService {
         logger.info("Learner enrolled successfully: {}", moodleLeanerId);
 
         return "Enrolled learner id "+moodleCourseId;
+    }
+
+    @Override
+    public List<MoodlePageContentResponse> fetchContent(int moodleCourseId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + token + "&wsfunction=mod_page_get_pages_by_courses&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("courseids[0]", String.valueOf(moodleCourseId));
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+
+        PageContentResponse response = objectMapper.readValue(
+                root.toString(),
+                PageContentResponse.class
+        );
+
+        logger.info("Fetched page content successfully for courseId={}", moodleCourseId);
+        return response.getPages();
     }
 
     public MoodleCourseResponse createCourse(String capsuleName) throws JsonProcessingException {

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleUserService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleUserService.java
@@ -38,11 +38,15 @@ public class MoodleUserService implements UserService {
 
         String url = moodleUrl + "?wstoken=" + token + "&wsfunction=core_user_create_users&moodlewsrestformat=json";
 
+        // create default password if is not set
+        String defaultPassword = userDto.getPassword() == null ? userDto.getUsername()+String
+                .valueOf(userDto.getUsername()
+                .charAt(0)).toUpperCase()+"1!" : userDto.getPassword();
         //moodle expects parameters
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("users[0][username]", userDto.getUsername());
-        params.add("users[0][password]", userDto.getPassword());
-        params.add("users[0][firstname]", userDto.getFirstName());
+        params.add("users[0][password]", defaultPassword);
+        params.add("users[0][firstname]", userDto.getUsername());
         params.add("users[0][lastname]", userDto.getLastName());
         params.add("users[0][email]", userDto.getEmail());
         params.add("users[0][auth]", "manual");


### PR DESCRIPTION
# 🚀 Pull Request: Fetch the lesson's content from Moodle

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-21: Fetch lesson's content from Moodle to Versapath.](https://amali-tech.atlassian.net/browse/VER-150)

---

## ✅ Summary

These changes implement the learner's enrolment in a particular course to retrieve or fetch lesson content to allow a learner to take the course on the Versapath platform. 

---

## 📌 Feature

- [x] Enrol learner in a course
- [x] Fetch all lessons' contents in a course.
- [x] Customize Moodle function to fetch a single lesson content.

---

## 🚧 Next Task

- Synchronize/update learner progress status from Versapath to Moodle.