### PR TITLE
Send back lesson update event with Moode data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>2.2.6</version>
+			<version>2.2.7</version>
 		</dependency>
 <!--		lombok-->
 		<dependency>

--- a/src/main/java/com/capstone/lms_service/messaging/AssignSkillEventListener.java
+++ b/src/main/java/com/capstone/lms_service/messaging/AssignSkillEventListener.java
@@ -20,7 +20,7 @@ public class AssignSkillEventListener {
            logger.info("Start assigning lesson to capsule: {}", skillEvent);
 
            // create new lesson in a course
-           courseService.createPage(skillEvent.getMoodleCourseId(), skillEvent.getAtoms());
+           courseService.assignLessonToCourse(skillEvent);
        } catch (Exception ex) {
            logger.error("Failed to assign lesson: {}", ex.getMessage());
        }

--- a/src/main/java/com/capstone/lms_service/service/CourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/CourseService.java
@@ -2,8 +2,8 @@ package com.capstone.lms_service.service;
 
 import com.capstone.lms_service.dto.MoodleCourseResponse;
 import com.capstone.lms_service.dto.MoodlePageContentResponse;
-import com.capstone.lms_service.dto.MoodlePageResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.common.event.AssignAtomToCapsuleEvent;
 import org.common.event.CreateSkillEvent;
 
 import java.util.List;
@@ -13,5 +13,5 @@ public interface CourseService {
     String enrolLearnerInCourse(int moodleLeanerId, int moodleCourseId) throws JsonProcessingException;
     List<MoodlePageContentResponse> fetchContent(int moodleCourseId) throws JsonProcessingException;
     MoodlePageContentResponse fetchSingleContent(int moodleCourseId) throws JsonProcessingException;
-    List<MoodlePageResponse> createPage(int courseId, List<String> atoms) throws JsonProcessingException;
+    void assignLessonToCourse(AssignAtomToCapsuleEvent skillEvent) throws JsonProcessingException;
 }

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleCourseService.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.common.event.AssignAtomToCapsuleEvent;
 import org.common.event.CreateSkillEvent;
 import org.common.event.SkillAtom;
 import org.common.event.UpdateSkillEvent;
@@ -168,6 +169,36 @@ public class MoodleCourseService implements CourseService {
         return pageResponseList;
     }
 
+    @Override
+    public void assignLessonToCourse(AssignAtomToCapsuleEvent skillEvent) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + localToken
+                     + "&wsfunction=local_versapath_create_page&moodlewsrestformat=json";
+
+        List<MoodlePageResponse> pageResponseList = new ArrayList<>();
+
+        for(String atom : skillEvent.getAtoms()) {
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("courseid", ""+skillEvent.getMoodleCourseId()+"");
+            params.add("name", atom);
+            params.add("intro", "This is a placeholder created by VersaPath.");
+            params.add("content", "<p>Content to be added on Moodle</p>");
+
+            JsonNode root = moodleHttpRequest.sendRequest(params, url); // Send request
+
+            // Deserialize JSON to DTO
+            MoodlePageResponse response = objectMapper.treeToValue(root, MoodlePageResponse.class);
+
+            pageResponseList.add(response);
+            logger.info("New page created successful: {}", response.getName());
+
+        }
+
+        // send command to update lesson with Moodle information
+        sendEventCommandToUpdateLesson(pageResponseList, skillEvent);
+
+    }
+
     void sendEventCommandToUpdateSkillData(MoodleCourseResponse insertedCourse){
         logger.info("inside the send command skill {}", insertedCourse);
         List<SkillAtom> skillAtoms = new ArrayList<>();
@@ -185,6 +216,29 @@ public class MoodleCourseService implements CourseService {
         UpdateSkillEvent updateSkillEvent = UpdateSkillEvent.builder()
                 .courseId(insertedCourse.getId())
                 .name(insertedCourse.getShortname())
+                .skillAtoms(skillAtoms)
+                .build();
+
+        updateSkillProducer.sendUpdateSkillsCommand(updateSkillEvent);
+    }
+
+    void sendEventCommandToUpdateLesson(List<MoodlePageResponse> moodlePageResponse, AssignAtomToCapsuleEvent assignAtomToCapsuleEvent){
+        logger.info("inside the send command update lesson {}", moodlePageResponse);
+        List<SkillAtom> skillAtoms = new ArrayList<>();
+        // map Versapath skill atom to Moodle page
+        for(MoodlePageResponse page: moodlePageResponse){
+            SkillAtom skillAtom = SkillAtom.builder()
+                    .name(page.getName())
+                    .courseModuleId(page.getCmid())
+                    .pageId(page.getInstance())
+                    .build();
+
+            skillAtoms.add(skillAtom);
+        }
+        // map Versapath skill capsule to Moodle course
+        UpdateSkillEvent updateSkillEvent = UpdateSkillEvent.builder()
+                .courseId(assignAtomToCapsuleEvent.getMoodleCourseId())
+                .name(assignAtomToCapsuleEvent.getCourseName())
                 .skillAtoms(skillAtoms)
                 .build();
 


### PR DESCRIPTION
# 🚀 Pull Request: Create new lesson(s) in an existing course

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-21:Create skill structure on Moodle.](https://amali-tech.atlassian.net/browse/VER-141)

---

## ✅ Summary

Whenever there is a new assignment of an atom to a capsule in skill service, the LMS service listens to an event to add the additional atom/lesson to Moodle. Therefore, this PR's changes send back an event to update the lesson with Moodle IDs afterwards.

---

## 📌 Feature

- [x] Create a lesson update event with Moodle data 

---

## 🚧 Next Task

- Synchronize/update learner progress status from Versapath to Moodle.