### PR TITLE
Create assessment placeholder on Moodle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>2.2.7</version>
+			<version>2.2.9</version>
 		</dependency>
 <!--		lombok-->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>2.2.9</version>
+			<version>3.1</version>
 		</dependency>
 <!--		lombok-->
 		<dependency>

--- a/src/main/java/com/capstone/lms_service/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/lms_service/config/RabbitMQConfig.java
@@ -35,6 +35,9 @@ public class RabbitMQConfig {
     @Value("${USER_CREATE_ERROR_QUEUE}")
     private String userCreateErrorQueue;
 
+    @Value("${ASSESSMENT_UPDATE_QUEUE}")
+    private String assessmentUpdateQueue;
+
     @Bean
     public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
         return new Jackson2JsonMessageConverter();
@@ -86,6 +89,11 @@ public class RabbitMQConfig {
     @Bean
     public Queue createUserQueue() {
         return new Queue(userCreateQueue, true);
+    }
+
+    @Bean
+    public Queue updateAssessmentQueue() {
+        return new Queue(assessmentUpdateQueue, true);
     }
 
 }

--- a/src/main/java/com/capstone/lms_service/dto/AssessmentResponseDto.java
+++ b/src/main/java/com/capstone/lms_service/dto/AssessmentResponseDto.java
@@ -1,0 +1,16 @@
+package com.capstone.lms_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AssessmentResponseDto {
+    private int quizId;
+    private int moodleCourseId;
+    private int moodleCourseModuleId;
+}

--- a/src/main/java/com/capstone/lms_service/messaging/CreateAssessmentEventListener.java
+++ b/src/main/java/com/capstone/lms_service/messaging/CreateAssessmentEventListener.java
@@ -1,5 +1,6 @@
 package com.capstone.lms_service.messaging;
 
+import com.capstone.lms_service.service.AssessmentService;
 import lombok.RequiredArgsConstructor;
 import org.common.event.AssessmentEvent;
 import org.slf4j.Logger;
@@ -11,13 +12,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CreateAssessmentEventListener {
     private static final Logger logger = LoggerFactory.getLogger(CreateAssessmentEventListener.class);
+    private final AssessmentService assessmentService;
 
    @RabbitListener(queues = "${ASSESSMENT_CREATE_QUEUE}")
     public void createAssessment(AssessmentEvent assessmentEvent){
        try {
            logger.info("Start creating assessment: {}", assessmentEvent);
+           assessmentService.createAssessmentOnMoodle(assessmentEvent);
 
-           //TODO: create assessment on Moodle
        } catch (Exception ex) {
            logger.error("Failed to create assessment: {}", ex.getMessage());
        }

--- a/src/main/java/com/capstone/lms_service/messaging/CreateAssessmentEventListener.java
+++ b/src/main/java/com/capstone/lms_service/messaging/CreateAssessmentEventListener.java
@@ -1,0 +1,26 @@
+package com.capstone.lms_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.AssessmentEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreateAssessmentEventListener {
+    private static final Logger logger = LoggerFactory.getLogger(CreateAssessmentEventListener.class);
+
+   @RabbitListener(queues = "${ASSESSMENT_CREATE_QUEUE}")
+    public void createAssessment(AssessmentEvent assessmentEvent){
+       try {
+           logger.info("Start creating assessment: {}", assessmentEvent);
+
+           //TODO: create assessment on Moodle
+       } catch (Exception ex) {
+           logger.error("Failed to create assessment: {}", ex.getMessage());
+       }
+
+   }
+}

--- a/src/main/java/com/capstone/lms_service/messaging/UpdateAssessmentProducer.java
+++ b/src/main/java/com/capstone/lms_service/messaging/UpdateAssessmentProducer.java
@@ -1,0 +1,23 @@
+package com.capstone.lms_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.AssessmentUpdateEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateAssessmentProducer {
+    private final RabbitTemplate rabbitTemplate;
+    private static final Logger logger = LoggerFactory.getLogger(UpdateAssessmentProducer.class);
+    @Value("${ASSESSMENT_UPDATE_QUEUE}")
+    private String assessmentUpdateQueue;
+
+    public void sendUpdateAssessments(AssessmentUpdateEvent assessmentEvent) {
+        logger.info("Send command to update assessment data with Moodle info: {}", assessmentEvent);
+        rabbitTemplate.convertAndSend(assessmentUpdateQueue, assessmentEvent);
+    }
+}

--- a/src/main/java/com/capstone/lms_service/service/AssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/AssessmentService.java
@@ -1,0 +1,9 @@
+package com.capstone.lms_service.service;
+
+import com.capstone.lms_service.dto.AssessmentResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.common.event.AssessmentEvent;
+
+public interface AssessmentService {
+    void createAssessmentOnMoodle(AssessmentEvent assessmentEvent) throws JsonProcessingException;
+}

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -1,12 +1,14 @@
 package com.capstone.lms_service.service.impl;
 
 import com.capstone.lms_service.dto.AssessmentResponseDto;
+import com.capstone.lms_service.messaging.UpdateAssessmentProducer;
 import com.capstone.lms_service.service.AssessmentService;
 import com.capstone.lms_service.util.MoodleHttpRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.common.event.AssessmentEvent;
+import org.common.event.AssessmentUpdateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,6 +21,7 @@ import org.springframework.util.MultiValueMap;
 public class MoodleAssessmentService implements AssessmentService {
     private static final Logger logger = LoggerFactory.getLogger(MoodleAssessmentService.class);
     private final MoodleHttpRequest moodleHttpRequest = new MoodleHttpRequest();
+    private final UpdateAssessmentProducer updateAssessmentProducer;
 
     @Value("${MOODLE_URL}")
     private String moodleUrl;
@@ -49,8 +52,19 @@ public class MoodleAssessmentService implements AssessmentService {
                 .moodleCourseId(root.get("courseid").asInt())
                 .build();
 
+        sendEventToUpdateAssessment(responseDto, assessmentEvent);
+
         logger.info("Assessment created successfully in course {} with id {} and module {}", responseDto.getMoodleCourseId(),
                 responseDto.getQuizId(), responseDto.getMoodleCourseModuleId());
 
+    }
+
+    private void sendEventToUpdateAssessment(AssessmentResponseDto assessmentResponseDto, AssessmentEvent assessmentEvent){
+        AssessmentUpdateEvent assessmentUpdateEvent = AssessmentUpdateEvent.builder()
+                .assessmentName(assessmentEvent.getAssessmentName())
+                .moodleCourseModuleId(assessmentResponseDto.getMoodleCourseModuleId())
+                .quizId(assessmentResponseDto.getQuizId())
+                .build();
+        updateAssessmentProducer.sendUpdateAssessments(assessmentUpdateEvent);
     }
 }

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -1,0 +1,56 @@
+package com.capstone.lms_service.service.impl;
+
+import com.capstone.lms_service.dto.AssessmentResponseDto;
+import com.capstone.lms_service.service.AssessmentService;
+import com.capstone.lms_service.util.MoodleHttpRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.common.event.AssessmentEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Service
+@RequiredArgsConstructor
+public class MoodleAssessmentService implements AssessmentService {
+    private static final Logger logger = LoggerFactory.getLogger(MoodleAssessmentService.class);
+    private final MoodleHttpRequest moodleHttpRequest = new MoodleHttpRequest();
+
+    @Value("${MOODLE_URL}")
+    private String moodleUrl;
+
+    @Value("${LOCAL_CREATE_QUIZ}")
+    private String token;
+
+    @Override
+    public void createAssessmentOnMoodle(AssessmentEvent assessmentEvent) throws JsonProcessingException {
+
+        String url = moodleUrl + "?wstoken=" + token
+                     + "&wsfunction=local_quizapi_create_quiz&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("courseid", String.valueOf(assessmentEvent.getMoodleCourseId()));
+        params.add("name", assessmentEvent.getAssessmentName());
+        params.add("intro", "Assessment Placeholder From Versapath");
+        params.add("timelimit", String.valueOf(assessmentEvent.getTimeLimitMinutes() * 60)); // Moodle expects seconds
+        params.add("attempts", String.valueOf(assessmentEvent.getMaxAttempts()));
+        params.add("gradepass", String.valueOf(assessmentEvent.getPassingScore()));
+        params.add("grade", String.valueOf(100));
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+
+        AssessmentResponseDto responseDto = AssessmentResponseDto.builder()
+                .quizId(root.get("quizid").asInt())
+                .moodleCourseModuleId(root.get("coursemoduleid").asInt())
+                .moodleCourseId(root.get("courseid").asInt())
+                .build();
+
+        logger.info("Assessment created successfully in course {} with id {} and module {}", responseDto.getMoodleCourseId(),
+                responseDto.getQuizId(), responseDto.getMoodleCourseModuleId());
+
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request: Create assessment placeholder on Moodle

### 🎫 Jira Ticket  
[🔗 SPRINT-2/VER-24:Create assessment placeholder on moodle.](https://amali-tech.atlassian.net/browse/VER-190)

---

## ✅ Summary

Whenever an admin or mentor creates an assessment's metadata in the assessment service, the LMS service listens to an event to create its placeholder on Moodle. Therefore, this PR's changes not only implement that but also send back an event to update the assessment with Moodle IDs mapping to it.

---

## 📌 Feature

- [x] Create assessment placeholder on Moodle
- [x] Publish event to update assessment with Moodle IDs 

---

## 🚧 Next Task

- Fetch content/Questions of the assessment.
- Synchronize/update learner progress status from Versapath to Moodle