### PR TITLE
Retrieve assessment questions from Moodle

### DIFF
--- a/src/main/java/com/capstone/lms_service/controller/MoodleController.java
+++ b/src/main/java/com/capstone/lms_service/controller/MoodleController.java
@@ -1,8 +1,12 @@
 package com.capstone.lms_service.controller;
 
 import com.capstone.lms_service.dto.*;
+import com.capstone.lms_service.dto.quiz.AttemptDTO;
+import com.capstone.lms_service.dto.quiz.QuizAttemptDataDTO;
+import com.capstone.lms_service.dto.quiz.QuizDTO;
 import com.capstone.lms_service.service.CourseService;
 import com.capstone.lms_service.service.UserService;
+import com.capstone.lms_service.service.impl.MoodleAssessmentService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ import java.util.UUID;
 public class MoodleController {
     private final UserService userService;
     private final CourseService courseService;
+    private final MoodleAssessmentService moodleAssessmentService;
 
     @PostMapping("/create-user")
     @Operation(summary = "Insert learner on moodle", description = "This is a direct endpoint to insert leaner from Versapath to moodle ")
@@ -84,6 +88,20 @@ public class MoodleController {
                 .message("Fetch contents successfully!")
                 .errors(null)
                 .data(Map.of("item", responseCourse))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @GetMapping("/assessments/{courseId}/course")
+    @Operation(summary = "Fetch all the assessments by course id",
+            description = "This is a direct endpoint to fetch assessment of a particular course from Moodle")
+    public ResponseEntity<ClientResponseFormatDto> getQuizzesByCourse(@PathVariable Long courseId) throws JsonProcessingException {
+        List<QuizDTO> quizzes = moodleAssessmentService.getQuizzesByCourse(courseId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Assessments data fetched successfully!")
+                .errors(null)
+                .data(Map.of("item", quizzes))
                 .build();
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/src/main/java/com/capstone/lms_service/controller/MoodleController.java
+++ b/src/main/java/com/capstone/lms_service/controller/MoodleController.java
@@ -106,4 +106,18 @@ public class MoodleController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @PostMapping("assessments/{quizId}/start")
+    @Operation(summary = "Start assessment",
+            description = "This endpoint is the start of an assessment based on the attempt number")
+    public ResponseEntity<ClientResponseFormatDto> startQuizAttempt(@PathVariable Long quizId) throws JsonProcessingException {
+        AttemptDTO attempt = moodleAssessmentService.startQuizAttempt(quizId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Assessment has started!")
+                .errors(null)
+                .data(Map.of("item", attempt))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
 }

--- a/src/main/java/com/capstone/lms_service/controller/MoodleController.java
+++ b/src/main/java/com/capstone/lms_service/controller/MoodleController.java
@@ -120,4 +120,19 @@ public class MoodleController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @PostMapping("assessments/{quizId}/questions")
+    @Operation(summary = "Retrieve assessment questions",
+            description = "This endpoint is the start of an assessment based on the attempt number and " +
+                          "also retrieve questions related to the assessment")
+    public ResponseEntity<ClientResponseFormatDto> attempt(@PathVariable Long quizId) throws JsonProcessingException {
+        QuizAttemptDataDTO quizResponse = moodleAssessmentService.getQuizQuestions(quizId);
+        ClientResponseFormatDto response = ClientResponseFormatDto.builder()
+                .success(true)
+                .message("Assessment questions retrieved successfully!")
+                .errors(null)
+                .data(Map.of("item", quizResponse))
+                .build();
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
 }

--- a/src/main/java/com/capstone/lms_service/dto/quiz/AttemptDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/AttemptDTO.java
@@ -1,0 +1,22 @@
+package com.capstone.lms_service.dto.quiz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AttemptDTO {
+    private Long id;
+    private Long quiz;
+    private Long userid;
+    private Integer attempt;
+    private String state;
+    private Long timestart;
+    private Long timefinish;
+}

--- a/src/main/java/com/capstone/lms_service/dto/quiz/AttemptDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/AttemptDTO.java
@@ -17,6 +17,6 @@ public class AttemptDTO {
     private Long userid;
     private Integer attempt;
     private String state;
-    private Long timestart;
-    private Long timefinish;
+    private String timestart;
+    private String timefinish;
 }

--- a/src/main/java/com/capstone/lms_service/dto/quiz/MoodleResponseDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/MoodleResponseDTO.java
@@ -1,0 +1,23 @@
+package com.capstone.lms_service.dto.quiz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MoodleResponseDTO<T> {
+    private T data;
+    private String exception;
+    private String errorcode;
+    private String message;
+
+    public boolean hasError() {
+        return exception != null || errorcode != null;
+    }
+}

--- a/src/main/java/com/capstone/lms_service/dto/quiz/OptionDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/OptionDTO.java
@@ -1,0 +1,15 @@
+package com.capstone.lms_service.dto.quiz;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OptionDTO {
+    private String value;
+    private String label;
+}

--- a/src/main/java/com/capstone/lms_service/dto/quiz/QuestionDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/QuestionDTO.java
@@ -1,0 +1,25 @@
+package com.capstone.lms_service.dto.quiz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuestionDTO {
+    private Long slot;
+    private Long questionid;
+    private String type;
+    private String html;
+    private Double maxmark;
+    private Integer page;
+    private String questiontext;
+    private List<OptionDTO> options;
+}

--- a/src/main/java/com/capstone/lms_service/dto/quiz/QuizAttemptDataDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/QuizAttemptDataDTO.java
@@ -1,0 +1,19 @@
+package com.capstone.lms_service.dto.quiz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuizAttemptDataDTO {
+    private AttemptDTO attempt;
+    private List<QuestionDTO> questions;
+}

--- a/src/main/java/com/capstone/lms_service/dto/quiz/QuizDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/QuizDTO.java
@@ -1,0 +1,22 @@
+package com.capstone.lms_service.dto.quiz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuizDTO {
+    private Long id;
+    private String name;
+    private String intro;
+    private Integer timeLimit;
+    private Integer attempts;
+    private Integer grade;
+    private Integer questionCount;
+}

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -1,6 +1,8 @@
 package com.capstone.lms_service.service.impl;
 
 import com.capstone.lms_service.dto.AssessmentResponseDto;
+import com.capstone.lms_service.dto.PageContentResponse;
+import com.capstone.lms_service.dto.quiz.QuizDTO;
 import com.capstone.lms_service.messaging.UpdateAssessmentProducer;
 import com.capstone.lms_service.service.AssessmentService;
 import com.capstone.lms_service.util.MoodleHttpRequest;
@@ -16,6 +18,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MoodleAssessmentService implements AssessmentService {
@@ -28,6 +33,9 @@ public class MoodleAssessmentService implements AssessmentService {
 
     @Value("${LOCAL_CREATE_QUIZ}")
     private String token;
+
+    @Value("${WEBSERVICE_TOKEN}")
+    private String webToken;
 
     @Override
     public void createAssessmentOnMoodle(AssessmentEvent assessmentEvent) throws JsonProcessingException {
@@ -66,5 +74,32 @@ public class MoodleAssessmentService implements AssessmentService {
                 .quizId(assessmentResponseDto.getQuizId())
                 .build();
         updateAssessmentProducer.sendUpdateAssessments(assessmentUpdateEvent);
+    }
+
+    public List<QuizDTO> getQuizzesByCourse(Long courseId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + webToken + "&wsfunction=mod_quiz_get_quizzes_by_courses&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("courseids[0]", String.valueOf(courseId));
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+        JsonNode quizzes = root.get("quizzes");
+
+        List<QuizDTO> quizDTOList = new ArrayList<>();
+        for(JsonNode quiz: quizzes){
+            QuizDTO dto = QuizDTO.builder()
+                    .id(quiz.get("id").asLong())
+                    .name(quiz.get("name").asText())
+                    .attempts(quiz.get("attempts").asInt())
+                    .intro(quiz.get("intro").asText())
+                    .grade(quiz.get("grade").asInt())
+                    .timeLimit(quiz.get("timelimit").asInt())
+                    .questionCount(quiz.get("hasquestions").asInt())
+                    .build();
+            quizDTOList.add(dto);
+
+        }
+
+        return quizDTOList;
     }
 }

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -2,6 +2,7 @@ package com.capstone.lms_service.service.impl;
 
 import com.capstone.lms_service.dto.AssessmentResponseDto;
 import com.capstone.lms_service.dto.PageContentResponse;
+import com.capstone.lms_service.dto.quiz.AttemptDTO;
 import com.capstone.lms_service.dto.quiz.QuizDTO;
 import com.capstone.lms_service.messaging.UpdateAssessmentProducer;
 import com.capstone.lms_service.service.AssessmentService;
@@ -18,6 +19,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -101,5 +105,34 @@ public class MoodleAssessmentService implements AssessmentService {
         }
 
         return quizDTOList;
+    }
+
+    public AttemptDTO startQuizAttempt(Long quizId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + webToken + "&wsfunction=mod_quiz_start_attempt&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("quizid", String.valueOf(quizId));
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+        JsonNode attempt = root.get("attempt");
+
+        return AttemptDTO.builder()
+                .id(attempt.get("id").asLong())
+                .userid(attempt.get("userid").asLong())
+                .attempt(attempt.get("attempt").asInt())
+                .quiz(attempt.get("quiz").asLong())
+                .state(attempt.get("state").asText())
+                .timestart(getReadableTime(attempt.get("timestart").asLong()))
+                .timefinish(getReadableTime(attempt.get("timefinish").asLong()))
+                .build();
+    }
+
+    private String getReadableTime(Long time) {
+        if (time != null) {
+            Instant instant = Instant.ofEpochSecond(time);
+            LocalDateTime dateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+            return dateTime.toString();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -1,7 +1,6 @@
 package com.capstone.lms_service.service.impl;
 
 import com.capstone.lms_service.dto.AssessmentResponseDto;
-import com.capstone.lms_service.dto.PageContentResponse;
 import com.capstone.lms_service.dto.quiz.AttemptDTO;
 import com.capstone.lms_service.dto.quiz.QuestionDTO;
 import com.capstone.lms_service.dto.quiz.QuizAttemptDataDTO;
@@ -118,6 +117,8 @@ public class MoodleAssessmentService implements AssessmentService {
         JsonNode root = moodleHttpRequest.sendRequest(params, url);
         JsonNode attempt = root.get("attempt");
 
+        logger.info("Starting quiz attempt for quiz ID: {}", quizId);
+
         return AttemptDTO.builder()
                 .id(attempt.get("id").asLong())
                 .userid(attempt.get("userid").asLong())
@@ -134,7 +135,7 @@ public class MoodleAssessmentService implements AssessmentService {
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("attemptid", String.valueOf(attemptId));
-        params.add("page", "0");
+        params.add("page", "0"); // all questions are on the first page
 
         JsonNode root = moodleHttpRequest.sendRequest(params, url);
 
@@ -163,10 +164,22 @@ public class MoodleAssessmentService implements AssessmentService {
             questionDTOList.add(questionDTO);
         }
 
+        logger.info("Fetching questions for attempt ID: {}", attemptId);
+
         return QuizAttemptDataDTO.builder()
                 .attempt(attemptDTO)
                 .questions(questionDTOList)
                 .build();
+    }
+
+    public QuizAttemptDataDTO getQuizQuestions(Long quizId) throws JsonProcessingException {
+
+            AttemptDTO attempt = startQuizAttempt(quizId);
+
+            QuizAttemptDataDTO data = getAttemptData(attempt.getId());
+
+            logger.info("Retrieved {} questions", data.getQuestions().size());
+            return data;
     }
 
     private String getReadableTime(Long time) {

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -3,6 +3,8 @@ package com.capstone.lms_service.service.impl;
 import com.capstone.lms_service.dto.AssessmentResponseDto;
 import com.capstone.lms_service.dto.PageContentResponse;
 import com.capstone.lms_service.dto.quiz.AttemptDTO;
+import com.capstone.lms_service.dto.quiz.QuestionDTO;
+import com.capstone.lms_service.dto.quiz.QuizAttemptDataDTO;
 import com.capstone.lms_service.dto.quiz.QuizDTO;
 import com.capstone.lms_service.messaging.UpdateAssessmentProducer;
 import com.capstone.lms_service.service.AssessmentService;
@@ -124,6 +126,46 @@ public class MoodleAssessmentService implements AssessmentService {
                 .state(attempt.get("state").asText())
                 .timestart(getReadableTime(attempt.get("timestart").asLong()))
                 .timefinish(getReadableTime(attempt.get("timefinish").asLong()))
+                .build();
+    }
+
+    public QuizAttemptDataDTO getAttemptData(Long attemptId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + webToken + "&wsfunction=mod_quiz_get_attempt_data&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("attemptid", String.valueOf(attemptId));
+        params.add("page", "0");
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+
+        JsonNode attempt = root.get("attempt");
+        AttemptDTO attemptDTO = AttemptDTO.builder()
+                .id(attempt.get("id").asLong())
+                .userid(attempt.get("userid").asLong())
+                .attempt(attempt.get("attempt").asInt())
+                .quiz(attempt.get("quiz").asLong())
+                .state(attempt.get("state").asText())
+                .timestart(getReadableTime(attempt.get("timestart").asLong()))
+                .timefinish(getReadableTime(attempt.get("timefinish").asLong()))
+                .build();
+
+        JsonNode questions = root.get("questions");
+        List<QuestionDTO> questionDTOList = new ArrayList<>();
+
+        for(JsonNode question: questions){
+            QuestionDTO questionDTO = QuestionDTO.builder()
+                    .slot(question.get("slot").asLong())
+                    .type(question.get("type").toString())
+                    .page(question.get("page").asInt())
+                    .html(question.get("html").toString())
+                    .questionid(question.get("questionnumber").asLong())
+                    .build();
+            questionDTOList.add(questionDTO);
+        }
+
+        return QuizAttemptDataDTO.builder()
+                .attempt(attemptDTO)
+                .questions(questionDTOList)
                 .build();
     }
 


### PR DESCRIPTION
# 🚀 Pull Request: Retrieve assessment questions from Moodle

### 🎫 Jira Ticket  
[🔗 SPRINT-3/VER-24:Retrieve assessment questions from Moodle.](https://amali-tech.atlassian.net/browse/VER-158)

---

## ✅ Summary

This PR introduces the fetching of assessment question contents from Moodle to Versapath. This is the first phase for a learner to start taking assessments on Versapath.

---

## 📌 Feature

- [x] Retrieve all the assessments of a course 
- [x] Allow the starting attempt of an assessment
- [x] Fetch all the questions on one page

---

## 🚧 Next Task

- Implement the assessment submission from Versapath to Moodle.