### PR TITLE
Retrieve learner's assessment result from Moodle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.common</groupId>
 			<artifactId>versapath-events</artifactId>
-			<version>3.1</version>
+			<version>3.1.9</version>
 		</dependency>
 <!--		lombok-->
 		<dependency>

--- a/src/main/java/com/capstone/lms_service/config/RabbitMQConfig.java
+++ b/src/main/java/com/capstone/lms_service/config/RabbitMQConfig.java
@@ -38,6 +38,9 @@ public class RabbitMQConfig {
     @Value("${ASSESSMENT_UPDATE_QUEUE}")
     private String assessmentUpdateQueue;
 
+    @Value("${ASSESSMENT_RESULT_QUEUE}")
+    private String assessmentResultQueue;
+
     @Bean
     public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
         return new Jackson2JsonMessageConverter();
@@ -95,5 +98,11 @@ public class RabbitMQConfig {
     public Queue updateAssessmentQueue() {
         return new Queue(assessmentUpdateQueue, true);
     }
+
+    @Bean
+    public Queue getAssessmentResultQueue() {
+        return new Queue(assessmentResultQueue, true);
+    }
+
 
 }

--- a/src/main/java/com/capstone/lms_service/dto/quiz/QuizResultDTO.java
+++ b/src/main/java/com/capstone/lms_service/dto/quiz/QuizResultDTO.java
@@ -1,0 +1,22 @@
+package com.capstone.lms_service.dto.quiz;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuizResultDTO {
+    private double grade;
+    private int attemptNumber;
+    private int quizId;
+    private LocalDateTime timeStart;
+    private LocalDateTime timeFinish;
+}

--- a/src/main/java/com/capstone/lms_service/messaging/AssessmentResultProducer.java
+++ b/src/main/java/com/capstone/lms_service/messaging/AssessmentResultProducer.java
@@ -1,0 +1,24 @@
+package com.capstone.lms_service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.common.event.AssessmentResultEvent;
+import org.common.event.AssessmentUpdateEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AssessmentResultProducer {
+    private final RabbitTemplate rabbitTemplate;
+    private static final Logger logger = LoggerFactory.getLogger(AssessmentResultProducer.class);
+    @Value("${ASSESSMENT_RESULT_QUEUE}")
+    private String assessmentResultQueue;
+
+    public void sendAssessmentResult(AssessmentResultEvent assessmentEvent) {
+        logger.info("Send command to persist assessment result info: {}", assessmentEvent);
+        rabbitTemplate.convertAndSend(assessmentResultQueue, assessmentEvent);
+    }
+}

--- a/src/main/java/com/capstone/lms_service/repository/UserSnapshotRepository.java
+++ b/src/main/java/com/capstone/lms_service/repository/UserSnapshotRepository.java
@@ -4,8 +4,11 @@ import com.capstone.lms_service.model.UserSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface UserSnapshotRepository extends JpaRepository<UserSnapshot, UUID> {
+    Optional<UserSnapshot> findUserSnapshotByMoodleUserToken(String learnerToken);
+
 }

--- a/src/main/java/com/capstone/lms_service/service/AssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/AssessmentService.java
@@ -1,9 +1,6 @@
 package com.capstone.lms_service.service;
 
-import com.capstone.lms_service.dto.quiz.QuizAttemptDataDTO;
-import com.capstone.lms_service.dto.quiz.QuizDTO;
-import com.capstone.lms_service.dto.quiz.QuizSubmissionRequest;
-import com.capstone.lms_service.dto.quiz.QuizSubmissionResponse;
+import com.capstone.lms_service.dto.quiz.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.common.event.AssessmentEvent;
 

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -3,6 +3,7 @@ package com.capstone.lms_service.service.impl;
 import com.capstone.lms_service.dto.AssessmentResponseDto;
 import com.capstone.lms_service.dto.quiz.*;
 import com.capstone.lms_service.exception.UserNotFoundException;
+import com.capstone.lms_service.messaging.AssessmentResultProducer;
 import com.capstone.lms_service.messaging.UpdateAssessmentProducer;
 import com.capstone.lms_service.model.UserSnapshot;
 import com.capstone.lms_service.repository.UserSnapshotRepository;
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
 import org.common.event.AssessmentEvent;
+import org.common.event.AssessmentResultEvent;
 import org.common.event.AssessmentUpdateEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +35,9 @@ public class MoodleAssessmentService implements AssessmentService {
     private static final Logger logger = LoggerFactory.getLogger(MoodleAssessmentService.class);
     private final MoodleHttpRequest moodleHttpRequest = new MoodleHttpRequest();
     private final UpdateAssessmentProducer updateAssessmentProducer;
+    private final AssessmentResultProducer assessmentResultProducer;
     private final UserSnapshotRepository userSnapshotRepository;
+
 
     @Value("${MOODLE_URL}")
     private String moodleUrl;
@@ -274,6 +278,8 @@ public class MoodleAssessmentService implements AssessmentService {
         logger.info("Finished the assessment: {}", root);
         QuizResultDTO quizResult = getGradeInfo(quizRequest.getAttemptId());
 
+        publishAssessmentResultEvent(learnerToken, quizResult);
+
         return QuizSubmissionResponse.builder()
                 .attemptId(quizRequest.getAttemptId())
                 .grade(quizResult.getGrade())
@@ -293,10 +299,10 @@ public class MoodleAssessmentService implements AssessmentService {
 
         return QuizResultDTO.builder()
                 .grade(root.get("grade").asDouble())
-                .quizId(root.get("quizid").asInt())
-                .attemptNumber(root.get("attempt").asInt())
-                .timeStart(getReadableDateTime(root.get("timestart").asLong()))
-                .timeFinish(getReadableDateTime(root.get("timefinish").asLong()))
+                .quizId(root.get("attempt").get("quiz").asInt())
+                .attemptNumber(root.get("attempt").get("attempt").asInt())
+                .timeStart(getReadableDateTime(root.get("attempt").get("timestart").asLong()))
+                .timeFinish(getReadableDateTime(root.get("attempt").get("timefinish").asLong()))
                 .build();
 
     }
@@ -307,5 +313,22 @@ public class MoodleAssessmentService implements AssessmentService {
             return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
         }
         return null;
+    }
+
+    void publishAssessmentResultEvent(String learnerToken, QuizResultDTO quizResult ){
+        UserSnapshot learner = userSnapshotRepository.findUserSnapshotByMoodleUserToken(learnerToken)
+                .orElseThrow(()-> new UserNotFoundException("User provide doesn't exist!!"));
+
+        AssessmentResultEvent assessmentResultEvent = AssessmentResultEvent.builder()
+                .userId(learner.getId())
+                .grade(quizResult.getGrade())
+                .attemptNumber(quizResult.getAttemptNumber())
+                .moodleQuizId(quizResult.getQuizId())
+                .timeFinish(quizResult.getTimeFinish())
+                .timeStart(quizResult.getTimeStart())
+                .build();
+
+        assessmentResultProducer.sendAssessmentResult(assessmentResultEvent);
+
     }
 }

--- a/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
+++ b/src/main/java/com/capstone/lms_service/service/impl/MoodleAssessmentService.java
@@ -272,10 +272,40 @@ public class MoodleAssessmentService implements AssessmentService {
         JsonNode root = moodleHttpRequest.sendRequest(params, url);
 
         logger.info("Finished the assessment: {}", root);
+        QuizResultDTO quizResult = getGradeInfo(quizRequest.getAttemptId());
 
         return QuizSubmissionResponse.builder()
                 .attemptId(quizRequest.getAttemptId())
+                .grade(quizResult.getGrade())
                 .state(root.get("state").asText())
                 .build();
+    }
+
+    public QuizResultDTO getGradeInfo(int attemptId) throws JsonProcessingException {
+        String url = moodleUrl + "?wstoken=" + webToken + "&wsfunction=mod_quiz_get_attempt_review&moodlewsrestformat=json";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("attemptid", String.valueOf(attemptId));
+
+        JsonNode root = moodleHttpRequest.sendRequest(params, url);
+
+        logger.info("Retrieved quiz info: {}", root);
+
+        return QuizResultDTO.builder()
+                .grade(root.get("grade").asDouble())
+                .quizId(root.get("quizid").asInt())
+                .attemptNumber(root.get("attempt").asInt())
+                .timeStart(getReadableDateTime(root.get("timestart").asLong()))
+                .timeFinish(getReadableDateTime(root.get("timefinish").asLong()))
+                .build();
+
+    }
+
+    private LocalDateTime getReadableDateTime(Long time) {
+        if (time != null) {
+            Instant instant = Instant.ofEpochSecond(time);
+            return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        }
+        return null;
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request: Retrieve learner's assessment result

### 🎫 Jira Ticket  
[🔗 SPRINT-3/VER-24:Retrieve learner's assessment result from Moodle.](https://amali-tech.atlassian.net/browse/VER-163)

---

## ✅ Summary

This PR enables learner to view their assessment result after submission and also publish an event so to persist the information in the assessment service database.

---

## 📌 Feature

- [x] Retrieve learner's grade after submission
- [x] Publish an assessment result event
